### PR TITLE
ISSUE-2: Update angular-cli?

### DIFF
--- a/angular-cli.json
+++ b/angular-cli.json
@@ -26,8 +26,8 @@
         "../node_modules/ebi-framework/js/foundationExtendEBI.js",
         "../node_modules/ebi-framework/js//script.js"
       ],
+      "environmentSource": "environments/environment.ts",
       "environments": {
-        "source": "environments/environment.ts",
         "dev": "environments/environment.ts",
         "prod": "environments/environment.prod.ts"
       }

--- a/package.json
+++ b/package.json
@@ -28,11 +28,11 @@
     "zone.js": "^0.7.2"
   },
   "devDependencies": {
+    "@angular/cli": "^1.4.9",
     "@angular/compiler-cli": "^2.3.1",
     "@types/jasmine": "2.5.38",
     "@types/jquery": "^2.0.15",
     "@types/node": "^6.0.42",
-    "angular-cli": "1.0.0-beta.28.3",
     "codelyzer": "~2.0.0-beta.1",
     "jasmine-core": "2.5.2",
     "jasmine-spec-reporter": "2.5.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "jquery": "^3.2.1",
     "rxjs": "^5.0.1",
     "ts-helpers": "^1.1.1",
+    "webpack-sources": "^1.0.1",
     "zone.js": "^0.7.2"
   },
   "devDependencies": {
@@ -44,6 +45,7 @@
     "protractor": "~4.0.13",
     "ts-node": "1.2.1",
     "tslint": "^4.3.0",
-    "typescript": "~2.0.3"
+    "typescript": "~2.0.3",
+    "webpack": "^3.8.1"
   }
 }

--- a/src/index.html
+++ b/src/index.html
@@ -4,7 +4,8 @@
   <meta charset="utf-8">
   <meta http-equiv="x-ua-compatible" content="ie=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-
+  <base href="/">
+  
   <!-- Async Google Analytics: change UA-71073175-1 to be your site's ID -->
   <script>
     window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;


### PR DESCRIPTION
On my machine (node: 6.9.1) it kept moaning:
```
Unable to find "@angular/cli" in devDependencies.

The package "angular-cli" has been deprecated and renamed to
"@angular/cli".

Please take the following steps to avoid issues:
"npm uninstall --save-dev angular-cli"
"npm install --save-dev @angular/cli@latest"

The "@angular/compiler-cli" package was not properly installed.
```

It also wanted a base href in the head.